### PR TITLE
apps-helpers was removed

### DIFF
--- a/.github/workflows/buid-status.yml
+++ b/.github/workflows/buid-status.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -19,8 +19,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Authenticate with private NPM package
-      run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
     - run: npm i
 
     - run: npm run test:coverage

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -17,13 +17,11 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - name: Use Node.js 16.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 16.x
+        node-version: 14.x
 
-    - name: Authenticate with private NPM package
-      run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
     - name: build readme
       run: |
         npm install

--- a/.github/workflows/coverage-status.yml
+++ b/.github/workflows/coverage-status.yml
@@ -12,12 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 16.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
-      - name: Authenticate with private NPM package
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          node-version: 14.x
       - name: Install dependencies
         run: npm install
       - name: Run coverage

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,8 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 16
-      - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          node-version: 14
       - run: npm i
       - run: npm run test:coverage
 
@@ -23,11 +22,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 14
           registry-url: https://registry.npmjs.org/
-      - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
       - run: npm i
       - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+
 
   send-slack-message:
       needs: publish-npm
@@ -36,7 +37,7 @@ jobs:
         - uses: actions/checkout@v2
         - uses: actions/setup-node@v1
           with:
-            node-version: 16
+            node-version: 14
         - run: bash ./scripts/release-notes.sh
           env:
             RELEASE_SLACK_WEBHOOK_URL: ${{secrets.RELEASE_SLACK_WEBHOOK_URL}}

--- a/lib/customEvent.js
+++ b/lib/customEvent.js
@@ -1,5 +1,4 @@
 import analytics from '@react-native-firebase/analytics';
-import {isString, isObject} from '@janiscommerce/apps-helpers';
 import {isDevEnv} from './utils';
 
 /**
@@ -17,10 +16,10 @@ import {isDevEnv} from './utils';
 
 const customEvent = async (eventName, dataEvent) => {
   try {
-    if (!eventName || !isString(eventName))
+    if (!eventName || typeof eventName !== 'string')
       throw new Error('Event name is required');
 
-    if (!dataEvent || !isObject(dataEvent))
+    if (!dataEvent || !Object.keys(dataEvent).length)
       throw new Error('Event data is required');
 
     await analytics().logEvent(eventName, dataEvent);

--- a/lib/userInfoEvent.js
+++ b/lib/userInfoEvent.js
@@ -1,5 +1,4 @@
 import analytics from '@react-native-firebase/analytics';
-import {isObject, isString} from '@janiscommerce/apps-helpers';
 import {isDevEnv} from './utils';
 
 /**
@@ -24,7 +23,7 @@ import {isDevEnv} from './utils';
 
 const userInfoEvent = async (params) => {
   try {
-    if (!params || !isObject(params) || !Object.keys(params).length)
+    if (!params || !Object.keys(params).length)
       throw new Error('Params are required');
 
     const {
@@ -40,15 +39,15 @@ const userInfoEvent = async (params) => {
     } = params;
 
     const eventData = {
-      ...(appName && isString(appName) && {appName}),
-      ...(appVersion && isString(appVersion) && {appVersion}),
-      ...(device && isString(device) && {device}),
-      ...(os && isString(os) && {os}),
-      ...(osVersion && isString(osVersion) && {osVersion}),
-      ...(userName && isString(userName) && {userName}),
-      ...(userId && isString(userId) && {userId}),
-      ...(language && isString(language) && {language}),
-      ...(client && isString(client) && {client}),
+      ...(appName && typeof appName === 'string' && {appName}),
+      ...(appVersion && typeof appVersion === 'string' && {appVersion}),
+      ...(device && typeof device === 'string' && {device}),
+      ...(os && typeof os === 'string' && {os}),
+      ...(osVersion && typeof osVersion === 'string' && {osVersion}),
+      ...(userName && typeof userName === 'string' && {userName}),
+      ...(userId && typeof userId === 'string' && {userId}),
+      ...(language && typeof language === 'string' && {language}),
+      ...(client && typeof client === 'string' && {client}),
     };
 
     if (!Object.keys(eventData).length)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@janiscommerce/app-analytics",
-      "version": "0.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
         "@react-native-firebase/analytics": "^18.3.0",
@@ -18,7 +18,6 @@
         "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
         "@babel/preset-env": "^7.22.10",
         "@babel/runtime": "^7.12.5",
-        "@janiscommerce/apps-helpers": "^1.6.2",
         "@react-native-community/eslint-config": "^2.0.0",
         "@react-native-firebase/analytics": "^18.3.0",
         "@react-native-firebase/app": "^18.3.0",
@@ -43,7 +42,6 @@
         "react-native": "^0.67.5"
       },
       "peerDependencies": {
-        "@janiscommerce/apps-helpers": "^1.6.2",
         "react": ">=17.0.2 <=18.2.0",
         "react-native": ">=0.67.5 <=0.72.0"
       }
@@ -2196,12 +2194,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@janiscommerce/apps-helpers": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@janiscommerce/apps-helpers/-/apps-helpers-1.6.2.tgz",
-      "integrity": "sha512-+Frqu5F82IXMRDif7H+uwa+h2BfUTwD0ZRkwaxUPPwfHX9mf0hKGdCaVA/uqDYK6X6vlnyapmNkS6rrkG8g0fQ==",
-      "dev": true
     },
     "node_modules/@jest/console": {
       "version": "26.6.2",
@@ -20060,12 +20052,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
-      "dev": true
-    },
-    "@janiscommerce/apps-helpers": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@janiscommerce/apps-helpers/-/apps-helpers-1.6.2.tgz",
-      "integrity": "sha512-+Frqu5F82IXMRDif7H+uwa+h2BfUTwD0ZRkwaxUPPwfHX9mf0hKGdCaVA/uqDYK6X6vlnyapmNkS6rrkG8g0fQ==",
       "dev": true
     },
     "@jest/console": {

--- a/package.json
+++ b/package.json
@@ -34,13 +34,11 @@
   },
   "peerDependencies": {
     "react": ">=17.0.2 <=18.2.0",
-    "react-native": ">=0.67.5 <=0.72.0",
-    "@janiscommerce/apps-helpers": "^1.6.2"
+    "react-native": ">=0.67.5 <=0.72.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.10",
     "@babel/preset-env": "^7.22.10",
-    "@janiscommerce/apps-helpers": "^1.6.2",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
     "@babel/runtime": "^7.12.5",


### PR DESCRIPTION
LINK DE TICKET: *

https://janiscommerce.atlassian.net/browse/APPSRN-195

DESCRIPCIÓN DEL REQUERIMIENTO: *
Se tiene que eliminar apps-helpers del package debido a que su uso es limitado y también complica las acciones de publicación.

DESCRIPCIÓN DE LA SOLUCIÓN: *

Se eliminó apps-helpers de las peerDependencies y devDependencies, y se reemplazó su uso en las validaciones de los metodos del package.

Se corrigieron las github.actions, eliminando la solicitud de permiso de la que dependíamos para instalar apps-helpers.
Se redujo la versión de node que utilizabamos en los workflows, ya que previamente había sido reemplazada de la 14 a la 16, ahora la reducimos a la 14.
