### PR TITLE
userInfo was updated with os and osVersion validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This dependency will allow that, when executing the methods of the package, thes
 ## Installation
 
 ```sh
-npm install @janis-commerce/app-analytics
+npm install @janiscommerce/app-analytics
 ```
 ## Usage
 
@@ -138,7 +138,7 @@ logs an event with information from the screen the user is viewing
 ```js
 import {screenViewEvent} from '@janiscommerce/app-analytics'
 
-screenViewEvent('home','class_home'})
+screenViewEvent('home','class_home')
 ```
 <a name="userInfoEvent"></a>
 

--- a/lib/screenViewEvent.js
+++ b/lib/screenViewEvent.js
@@ -11,7 +11,7 @@ import {isDevEnv} from './utils';
  * @example
  * import {screenViewEvent} from '@janiscommerce/app-analytics'
  *
- * screenViewEvent('home','class_home'})
+ * screenViewEvent('home','class_home')
  */
 
 const screenViewEvent = async (screenName, screenClass = '') => {

--- a/lib/userInfoEvent.js
+++ b/lib/userInfoEvent.js
@@ -1,5 +1,6 @@
 import analytics from '@react-native-firebase/analytics';
 import {isDevEnv} from './utils';
+import {boldRed, boldCian} from './utils/decorationText';
 
 /**
  * @function userInfoEvent
@@ -39,16 +40,44 @@ const userInfoEvent = async (params) => {
       client,
     } = params;
 
+    if (os && isDevEnv()) {
+      // eslint-disable-next-line no-console
+      console.info(
+        '\x1b[103m \x1b[1m\x1b[30m%s\x1b[0m',
+        'Deprecated prop alert: ',
+        '\nYou are implementing "os" as a property:\n\n',
+        params,
+        boldRed,
+        '\n\nFrom the next version this prop will be deprecated',
+        boldCian,
+        '\n',
+        'We recommend sending this data within the "osVersion" key',
+        '\x1b[0m',
+      );
+    }
+
+    const validOs = os && typeof os === 'string';
+
+    const parsedOSVersion =
+      validOs && !osVersion?.includes(os) ? `${os} ${osVersion}` : osVersion;
+
     const eventData = {
-      ...(appName && typeof appName === 'string' && {appName}),
+      ...(appName &&
+        typeof appName === 'string' && {appName: appName.toLowerCase()}),
       ...(appVersion && typeof appVersion === 'string' && {appVersion}),
-      ...(device && typeof device === 'string' && {device}),
-      ...(os && typeof os === 'string' && {os}),
-      ...(osVersion && typeof osVersion === 'string' && {osVersion}),
-      ...(userEmail && typeof userEmail === 'string' && {userEmail}),
-      ...(userId && typeof userId === 'string' && {userId}),
+      ...(device &&
+        typeof device === 'string' && {device: device.toLowerCase()}),
+      ...(osVersion &&
+        typeof osVersion === 'string' && {
+          osVersion: parsedOSVersion.toLowerCase(),
+        }),
+      ...(userEmail &&
+        typeof userEmail === 'string' && {userEmail: userEmail.toLowerCase()}),
+      ...(userId &&
+        typeof userId === 'string' && {userId: userId.toLowerCase()}),
       ...(language && typeof language === 'string' && {language}),
-      ...(client && typeof client === 'string' && {client}),
+      ...(client &&
+        typeof client === 'string' && {client: client.toLowerCase()}),
     };
 
     if (!Object.keys(eventData).length)

--- a/lib/userInfoEvent.js
+++ b/lib/userInfoEvent.js
@@ -45,17 +45,22 @@ const userInfoEvent = async (params) => {
       console.info(
         '\n\n\n',
         '\x1b[103m \x1b[1m\x1b[30m',
-        'DEPRECATED PROP ALERT: ','\x1b[0m',
+        'DEPRECATED PROP ALERT: ',
+        '\x1b[0m',
         '\n\nYou are implementing "os" as a property:\n',
         '\nuserInfoEvent({os:"android",osVersion:"12"}',
-        boldRed, 'x',
+        boldRed,
+        'x',
         '\n\nFrom the next version the "os" prop will be deprecated.\n',
         boldCian,
-        '\n','We recommend that you submit the O.System information as follows: \n',
+        '\n',
+        'We recommend that you submit the O.System information as follows: \n',
         '\x1b[0m',
         '\nuserInfoEvent({osVersion:"android 12"}',
         boldGreen,
-        '✓', '\n\nYou will need to change the implementation before the next package update!','\x1b[0m'
+        '✓',
+        '\n\nYou will need to change the implementation before the next package update!',
+        '\x1b[0m',
       );
     }
 

--- a/lib/userInfoEvent.js
+++ b/lib/userInfoEvent.js
@@ -1,6 +1,6 @@
 import analytics from '@react-native-firebase/analytics';
 import {isDevEnv} from './utils';
-import {boldRed, boldCian} from './utils/decorationText';
+import {boldRed, boldCian, boldGreen} from './utils/decorationText';
 
 /**
  * @function userInfoEvent
@@ -43,16 +43,19 @@ const userInfoEvent = async (params) => {
     if (os && isDevEnv()) {
       // eslint-disable-next-line no-console
       console.info(
-        '\x1b[103m \x1b[1m\x1b[30m%s\x1b[0m',
-        'Deprecated prop alert: ',
-        '\nYou are implementing "os" as a property:\n\n',
-        params,
-        boldRed,
-        '\n\nFrom the next version this prop will be deprecated',
+        '\n\n\n',
+        '\x1b[103m \x1b[1m\x1b[30m',
+        'DEPRECATED PROP ALERT: ','\x1b[0m',
+        '\n\nYou are implementing "os" as a property:\n',
+        '\nuserInfoEvent({os:"android",osVersion:"12"}',
+        boldRed, 'x',
+        '\n\nFrom the next version the "os" prop will be deprecated.\n',
         boldCian,
-        '\n',
-        'We recommend sending this data within the "osVersion" key',
+        '\n','We recommend that you submit the O.System information as follows: \n',
         '\x1b[0m',
+        '\nuserInfoEvent({osVersion:"android 12"}',
+        boldGreen,
+        '✓', '\n\nYou will need to change the implementation before the next package update!','\x1b[0m'
       );
     }
 

--- a/lib/utils/decorationText.js
+++ b/lib/utils/decorationText.js
@@ -2,4 +2,6 @@ const boldRed = '\x1b[91m\x1b[1m';
 
 const boldCian = '\x1b[36m\x1b[1m';
 
-export {boldRed, boldCian};
+const boldGreen = '\x1b[92m\x1b[1m'
+
+export {boldRed, boldCian, boldGreen};

--- a/lib/utils/decorationText.js
+++ b/lib/utils/decorationText.js
@@ -1,0 +1,5 @@
+const boldRed = '\x1b[91m\x1b[1m';
+
+const boldCian = '\x1b[36m\x1b[1m';
+
+export {boldRed, boldCian};

--- a/template-readme.hbs
+++ b/template-readme.hbs
@@ -78,7 +78,7 @@ This dependency will allow that, when executing the methods of the package, thes
 ## Installation
 
 ```sh
-npm install @janis-commerce/app-analytics
+npm install @janiscommerce/app-analytics
 ```
 ## Usage
 


### PR DESCRIPTION
LINK DE TICKET: *
https://janiscommerce.atlassian.net/browse/APPSRN-220

DESCRIPCIÓN DEL REQUERIMIENTO: *

CONTEXTO

Actualmente, userInfo está enviando la información del sistema operativo separada de su respectiva versión, haciendo una diferenciación entre os y osVersion, por lo que la info que llega a analytics tiene el siguiente formato:
os: android,
osVersion: 12

Dejando un dato disociado del otro.

Esto en las apps se adaptó para que en el campo osVersion enviemos tanto el sistema operativo como su versión, pero aún enviamos el os como dato extra aparte.
NECESIDAD

Debemos unificar toda la información (os y osVersion) en el campo osVersion para que el evento envíe 1 de los 2 parametros.

DESCRIPCIÓN DE LA SOLUCIÓN: *

Lo que se agregó fue una validación en **userInfoEvent** que, en entornos de desarrollo, detecta si se ha recibido una prop "os" dentro de la data pasada como argumento. En caso de ser así esta validación se encarga de mostrar un mensaje en consola que haga referencia a una futura "deprecación" de esta prop y una sugerencia de a dónde redirigir la información asociada a "os"

El funcionamiento del método userInfoEvent es el mismo, agregando el metodo toLowerCase() a cada prop recibida para que los datos tengan un formato especifico. (Esto no aplica a la prop APP_VERSION ni tampoco a la prop LANGUAGE)

Se agregó un ternario que se encarga de validar si "osVersion" ya contiene la información de "os", ¿por qué se hizo esto? Porque si ya lo incluia y no validasemos podría darse el caso de que en analytics se reciba un dato con este formato:

`osVersion: android android 12`

Se corrigieron errores en la documentación


CÓMO SE PUEDE PROBAR? *
Para probarlo se pueden usar los test de la función userInfoEvent. Si la ejecuta el mensaje se mostrará en su consola y le sugerirá cómo proseguir. Otra manera sería vincularlo a alguna de las 3 apps y ejecutar el metodo userInfoEvent. Cómo las 3 apps ya usan el metodo bastará con cambiar la importación desde donde se extrae la función y quitar la validación de entorno de desarrollo que se encuentra en la home

SCREENSHOTS:

![Captura desde 2023-10-05 19-02-38](https://github.com/janis-commerce/app-analytics/assets/75044106/924f15d9-2e2d-436c-b77a-e9d24b0d28e9)

